### PR TITLE
feature(Cli): options for protocol and hostname

### DIFF
--- a/bin/lcp.js
+++ b/bin/lcp.js
@@ -7,6 +7,8 @@ const prompt = require("prompt-sync")();
 
 var optionDefinitions = [
   { name: "proxyPort", alias: "p", type: Number, defaultValue: 8010 },
+  { name: "protocol", type: String, defaultValue: "http" },
+  { name: "hostname", type: String, defaultValue: "localhost" },
   { name: "port", type: String },
   { name: "credentials", type: Boolean, defaultValue: false },
   { name: "origin", type: String, defaultValue: "*" },
@@ -77,7 +79,7 @@ try {
     }
     lcp.startProxy(
       options.proxyPort,
-      "http://localhost:" + options.port,
+      options.protocol + "://" + options.hostname + ":" + options.port,
       options.credentials,
       options.origin,
       options.webhookStore,


### PR DESCRIPTION
Hi :wave:,

Firstly, thanks for your work on this project !

This is very useful to us, however we have a specific local setup: we use a full [HTTPS development environment](https://dev.to/nightbr/full-https-ssl-development-environment-4dam).

Currently, I've found a work around using [patch-package](https://www.npmjs.com/package/patch-package) but it would be very nice to be able to set the `protocol` and `hostname` in the options of the webhook-store-ci